### PR TITLE
Add public key to challenge computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change challenge computation adding the public key to the hash [#3]
+
 ## [0.1.0] - 2024-01-08
 
 ### Added
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial commit, this package continues the development of [dusk-schnorr](https://github.com/dusk-network/schnorr/) at version `0.18.0` under the new name: jubjub-schnorr
 
 <!-- ISSUES -->
+[#3]: https://github.com/dusk-network/jubjub-schnorr/issues/3
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.1.0...HEAD

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ To sign a message $m \in \mathbb{F}_q^×$:
 
 - Choose a random private nonce $r \in \mathbb{F}_p^×$.
 - Compute nonce point $R = rG \in \mathbb{G}$.
-- Compute challenge hash $c = H(R \parallel m) \in \mathbb{F}_p$ where $\parallel$ denotes concatenation and $R$ is represented as a bit string.
+- Compute challenge hash $c = H(R \parallel $PK \parallel m) \in \mathbb{F}_p$ where $\parallel$ denotes concatenation and $R$ is represented as a bit string.
 - Compute $u = r − sk \cdot c \in \mathbb{F}_p$.
 
 The signature is the tuple $(u, R) \in \mathbb{F}_p \times \mathbb{G}$.
 
 #### Verifying
 
-- Compute challenge hash $c = H(R \parallel m) \in \mathbb{F}_p$.
+- Compute challenge hash $c = H(R \parallel $PK \parallel m) \in \mathbb{F}_p$.
 - Verify that $uG + cPK = R$.
 
 If the signature was signed with the secret key corresponding to $PK$, this will hold true, since:
@@ -83,14 +83,14 @@ To sign a message $m \in \mathbb{F}_q^×$:
 
 - Choose a random private nonce $r \in \mathbb{F}_p^×$.
 - Compute nonce points $R = rG \in \mathbb{G}$ and $R' = rG' \in \mathbb{G}$.
-- Compute challenge hash $c = H(R \parallel R' \parallel m) \in \mathbb{F}_p$ where $\parallel$ denotes concatenation and $R, R'$ are represented as a bit strings.
+- Compute challenge hash $c = H(R \parallel R' \parallel $PK \parallel m) \in \mathbb{F}_p$ where $\parallel$ denotes concatenation and $R, R'$ are represented as a bit strings.
 - Compute $u = r − sk \cdot c \in \mathbb{F}_p$.
 
 The signature is the tuple $(u, R, R') \in \mathbb{F}_p \times \mathbb{G} \times \mathbb{G}$.
 
 #### Verifying
 
-- Compute challenge hash $c = H(R \parallel R' \parallel m) \in \mathbb{F}_p$.
+- Compute challenge hash $c = H(R \parallel R' \parallel $PK \parallel m) \in \mathbb{F}_p$.
 - Verify that $rG + cPK = R$ and $uG' + cPK' = R'$.
 
 If the signature was signed with the correct private key, this should hold true because:

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -55,7 +55,10 @@ pub fn verify_signature(
     let r_x = *r.x();
     let r_y = *r.y();
 
-    let challenge = [r_x, r_y, msg];
+    let pk_x = *pk.x();
+    let pk_y = *pk.y();
+
+    let challenge = [r_x, r_y, pk_x, pk_y, msg];
     let challenge_hash = sponge::truncated::gadget(composer, &challenge);
 
     let s_a = composer.component_mul_generator(u, GENERATOR_EXTENDED)?;
@@ -111,7 +114,10 @@ pub fn verify_signature_double(
     let r_p_x = *r_p.x();
     let r_p_y = *r_p.y();
 
-    let challenge = [r_x, r_y, r_p_x, r_p_y, msg];
+    let pk_x = *pk.x();
+    let pk_y = *pk.y();
+
+    let challenge = [r_x, r_y, r_p_x, r_p_y, pk_x, pk_y, msg];
     let challenge_hash = sponge::truncated::gadget(composer, &challenge);
 
     let s_a = composer.component_mul_generator(u, GENERATOR_EXTENDED)?;
@@ -170,7 +176,10 @@ pub fn verify_signature_var_gen(
     let r_x = *r.x();
     let r_y = *r.y();
 
-    let challenge = [r_x, r_y, msg];
+    let pk_x = *pk.x();
+    let pk_y = *pk.y();
+
+    let challenge = [r_x, r_y, pk_x, pk_y, msg];
     let challenge_hash = sponge::truncated::gadget(composer, &challenge);
 
     // TODO: check whether we need to append the generator as a constant

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -120,7 +120,7 @@ impl PublicKey {
     /// A boolean value indicating the validity of the Schnorr [`Signature`].
     pub fn verify(&self, sig: &Signature, message: BlsScalar) -> bool {
         // Compute challenge value, c = H(R||pk||m);
-        let c = crate::signatures::challenge_hash(sig.R(), message, *self);
+        let c = crate::signatures::challenge_hash(sig.R(), *self, message);
 
         // Compute verification steps
         // u * G + c * PK
@@ -228,8 +228,8 @@ impl PublicKeyDouble {
         let c = crate::signatures::challenge_hash_double(
             sig_double.R(),
             sig_double.R_prime(),
-            message,
             self.pk().into(),
+            message  
         );
 
         // Compute verification steps
@@ -386,9 +386,9 @@ impl PublicKeyVarGen {
 
     /// Verifies that the given Schnorr [`SignatureVarGen`] is valid.
     ///
-    /// This function computes a challenge hash using the stored `R` point and
-    /// the provided message, then performs the verification by checking the
-    /// equality of `u * G + c * PK` and `R`.
+    /// This function computes a challenge hash using the stored `R` point, the
+    /// public key `pk`, and the provided message, then performs the verification 
+    /// by checking the equality of `u * G + c * PK` and `R`.
     ///
     /// ## Parameters
     ///
@@ -407,8 +407,8 @@ impl PublicKeyVarGen {
         // Compute challenge value, c = H(R||pk||m);
         let c = crate::signatures::challenge_hash(
             sig_var_gen.R(),
-            message,
             self.public_key().into(),
+            message,
         );
 
         // Compute verification steps

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -229,7 +229,7 @@ impl PublicKeyDouble {
             sig_double.R(),
             sig_double.R_prime(),
             self.pk().into(),
-            message  
+            message,
         );
 
         // Compute verification steps
@@ -387,8 +387,8 @@ impl PublicKeyVarGen {
     /// Verifies that the given Schnorr [`SignatureVarGen`] is valid.
     ///
     /// This function computes a challenge hash using the stored `R` point, the
-    /// public key `pk`, and the provided message, then performs the verification 
-    /// by checking the equality of `u * G + c * PK` and `R`.
+    /// public key `pk`, and the provided message, then performs the
+    /// verification by checking the equality of `u * G + c * PK` and `R`.
     ///
     /// ## Parameters
     ///

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -237,8 +237,8 @@ impl SecretKey {
         let c = crate::signatures::challenge_hash_double(
             &R,
             &R_prime,
-            message,
             PublicKey::from(self),
+            message,
         );
 
         // Compute scalar signature, u = r - c * sk,
@@ -453,7 +453,7 @@ impl SecretKeyVarGen {
         let c = crate::signatures::challenge_hash_var_gen(
             &R,
             PublicKeyVarGen::from(self),
-            msg
+            msg,
         );
 
         // Compute scalar signature, U = r - c * sk,

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -111,7 +111,7 @@ impl SecretKey {
     /// This function performs the following cryptographic operations:
     /// - Generates a random nonce `r`.
     /// - Computes `R = r * G`.
-    /// - Computes the challenge `c = H(R || m)`.
+    /// - Computes the challenge `c = H(R || pk || m)`.
     /// - Computes the signature `u = r - c * sk`.
     ///
     /// ## Parameters
@@ -162,7 +162,7 @@ impl SecretKey {
 
         // Compute challenge value, c = H(R||pk||m);
         let c =
-            crate::signatures::challenge_hash(&R, msg, PublicKey::from(self));
+            crate::signatures::challenge_hash(&R, PublicKey::from(self), msg);
 
         // Compute scalar signature, U = r - c * sk,
         let u = r - (c * self.as_ref());
@@ -399,7 +399,7 @@ impl SecretKeyVarGen {
     /// This function performs the following cryptographic operations:
     /// - Generates a random nonce `r`.
     /// - Computes `R = r * G`.
-    /// - Computes the challenge `c = H(R || m)`.
+    /// - Computes the challenge `c = H(R || pk || m)`.
     /// - Computes the signature `u = r - c * sk`.
     ///
     /// ## Parameters
@@ -452,8 +452,8 @@ impl SecretKeyVarGen {
         // Compute challenge value, c = H(R||pk||m);
         let c = crate::signatures::challenge_hash_var_gen(
             &R,
-            msg,
             PublicKeyVarGen::from(self),
+            msg
         );
 
         // Compute scalar signature, U = r - c * sk,

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -18,6 +18,11 @@ use dusk_poseidon::sponge::truncated::hash;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(feature = "var_generator")]
+use crate::PublicKeyVarGen;
+
+use crate::PublicKey;
+
 /// An Schnorr signature, produced by signing a message with a [`SecretKey`].
 ///
 /// ## Fields
@@ -127,10 +132,18 @@ impl Serializable<64> for Signature {
 pub(crate) fn challenge_hash(
     R: &JubJubExtended,
     message: BlsScalar,
+    pk: PublicKey,
 ) -> JubJubScalar {
     let R_coordinates = R.to_hash_inputs();
+    let pk_coordinates = pk.as_ref().to_hash_inputs();
 
-    hash(&[R_coordinates[0], R_coordinates[1], message])
+    hash(&[
+        R_coordinates[0],
+        R_coordinates[1],
+        pk_coordinates[0],
+        pk_coordinates[1],
+        message,
+    ])
 }
 
 /// Structure representing a Schnorr signature with a double-key mechanism.
@@ -276,15 +289,19 @@ pub(crate) fn challenge_hash_double(
     R: &JubJubExtended,
     R_prime: &JubJubExtended,
     message: BlsScalar,
+    pk: PublicKey,
 ) -> JubJubScalar {
     let R_coordinates = R.to_hash_inputs();
     let R_p_coordinates = R_prime.to_hash_inputs();
+    let pk_coordinates = pk.as_ref().to_hash_inputs();
 
     hash(&[
         R_coordinates[0],
         R_coordinates[1],
         R_p_coordinates[0],
         R_p_coordinates[1],
+        pk_coordinates[0],
+        pk_coordinates[1],
         message,
     ])
 }
@@ -401,4 +418,24 @@ impl Serializable<64> for SignatureVarGen {
 
         Ok(Self { u, R })
     }
+}
+
+// Create a challenge hash for the double signature scheme.
+#[cfg(feature = "var_generator")]
+#[allow(non_snake_case)]
+pub(crate) fn challenge_hash_var_gen(
+    R: &JubJubExtended,
+    message: BlsScalar,
+    pk: PublicKeyVarGen,
+) -> JubJubScalar {
+    let R_coordinates = R.to_hash_inputs();
+    let pk_coordinates = pk.public_key().to_hash_inputs();
+
+    hash(&[
+        R_coordinates[0],
+        R_coordinates[1],
+        pk_coordinates[0],
+        pk_coordinates[1],
+        message,
+    ])
 }

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -420,7 +420,7 @@ impl Serializable<64> for SignatureVarGen {
     }
 }
 
-// Create a challenge hash for the double signature scheme.
+// Create a challenge hash for the signature scheme with a variable generator.
 #[cfg(feature = "var_generator")]
 #[allow(non_snake_case)]
 pub(crate) fn challenge_hash_var_gen(

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -131,8 +131,8 @@ impl Serializable<64> for Signature {
 #[allow(non_snake_case)]
 pub(crate) fn challenge_hash(
     R: &JubJubExtended,
-    message: BlsScalar,
     pk: PublicKey,
+    message: BlsScalar,
 ) -> JubJubScalar {
     let R_coordinates = R.to_hash_inputs();
     let pk_coordinates = pk.as_ref().to_hash_inputs();
@@ -288,8 +288,8 @@ impl Serializable<96> for SignatureDouble {
 pub(crate) fn challenge_hash_double(
     R: &JubJubExtended,
     R_prime: &JubJubExtended,
-    message: BlsScalar,
     pk: PublicKey,
+    message: BlsScalar,
 ) -> JubJubScalar {
     let R_coordinates = R.to_hash_inputs();
     let R_p_coordinates = R_prime.to_hash_inputs();
@@ -425,8 +425,8 @@ impl Serializable<64> for SignatureVarGen {
 #[allow(non_snake_case)]
 pub(crate) fn challenge_hash_var_gen(
     R: &JubJubExtended,
-    message: BlsScalar,
     pk: PublicKeyVarGen,
+    message: BlsScalar,
 ) -> JubJubScalar {
     let R_coordinates = R.to_hash_inputs();
     let pk_coordinates = pk.public_key().to_hash_inputs();


### PR DESCRIPTION
We were using a weak Fiat-Shamir protocol when computing the challenges `c = Hash(R, m)` and  `c = Hash(R, R', m)` in the single-key and double-key Schnorr signatures, respectively. Considering the Dusk stack, where the public key is prefixed and part of a merkle proof, this is fine. However, using the aforesaid signature schemes in other contexts could be prone to security issues, as described in the following references:

- https://ed25519.cr.yp.to/multischnorr-20151012.pdf [Section 2.4]
- https://www.cryptrec.go.jp/exreport/cryptrec-ex-3003-2020.pdf [Section 7.7]
- https://eprint.iacr.org/2016/771.pdf

This PR adds the public key to the challenge computation. For what concerns the circuits, the double-key version only grows 1 constraint, and the single one ~1000.