### PR TITLE
Bump to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-01-24
+
 ### Changed
 
 - Change challenge computation adding the public key to the hash [#3]
@@ -21,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/jubjub-schnorr/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/jubjub-schnorr/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-schnorr"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/jubjub-schnorr"


### PR DESCRIPTION
## [0.2.0] - 2024-01-24

### Changed

- Change challenge computation adding the public key to the hash [#3]

[0.2.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.1.0...v0.2.0
