### PR TITLE
Bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-04-24
+
 ### Changed
 
 - Change `verify` methods to return a `Result` instead of a `bool` [#14]
@@ -54,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2]: https://github.com/dusk-network/jubjub-schnorr/issues/2
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-schnorr"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/jubjub-schnorr"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-05-22"
+channel = "nightly-2023-11-10"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## [0.3.0] - 2024-04-24

### Changed

- Change `verify` methods to return a `Result` instead of a `bool` [#14]

### Added

- Add `Zeroize` trait implementation for `SecretKey` [#12]
- Add enum `Error` to differeniate different errors in signature verification [#14]
- Add point validity checks in signature verifications [#14]

### Removed

- Remove `Copy` trait from `SecretKey` [#12]
- Remove `From<SecretKey>` for `PublicKey`, use `From<&SecretKey>` instead [#12]


[0.3.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.2...v0.3.0
