### PR TITLE
Bump to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-08-14
+
+### Changed
+
+- Update to dusk-plonk v0.20.0
+- Update to dusk-poseidon v0.40.0
+
 ## [0.4.0] - 2024-05-22
 
 ### Removed
@@ -76,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2]: https://github.com/dusk-network/jubjub-schnorr/issues/2
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.1...v0.2.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-schnorr"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/jubjub-schnorr"
@@ -17,14 +17,14 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
-dusk-poseidon = "0.39"
+dusk-poseidon = "0.40"
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false, features = ["zeroize"] }
 ff = { version = "0.13", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
-dusk-plonk = { version = "0.19", default-features = false, features = ["alloc"], optional = true }
+dusk-plonk = { version = "0.20", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }


### PR DESCRIPTION
## [0.5.0] - 2024-08-14

### Changed

- Update to dusk-plonk v0.20
- Update to dusk-poseidon v0.40

[0.5.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.4.0...v0.5.0
