### PR TITLE
Release `0.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-12-17
+
 ### Added
 
 - Add serde `Serialize` and `Deserialize` implementations for `PublicKey`, `SecretKey`, `Signature`,
@@ -91,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2]: https://github.com/dusk-network/jubjub-schnorr/issues/2
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.2.2...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-schnorr"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/jubjub-schnorr"


### PR DESCRIPTION
## [0.5.1] - 2024-12-17

### Added

- Add serde `Serialize` and `Deserialize` implementations for `PublicKey`, `SecretKey`, `Signature`,
`PublicKeyDouble`, `SignatureDouble`, `PublicKeyVarGen`, `SecretKeyVarGen` and `SignatureVarGen` [#29]
- Add `serde`, `bs58` and `serde_json` optional dependencies [#29]
- Add `serde` feature [#29]

[0.5.1]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.0...v0.5.1