### PR TITLE
Release `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-02-06
+
 ### Changed
 
 - Update `dusk-poseidon` to v0.41
@@ -100,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2]: https://github.com/dusk-network/jubjub-schnorr/issues/2
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/jubjub-schnorr/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-schnorr"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/jubjub-schnorr"


### PR DESCRIPTION
## [0.6.0](https://github.com/dusk-network/jubjub-schnorr/compare/v0.5.1...v0.6.0) - 2025-02-06

### Changed

- Update `dusk-poseidon` to v0.41
- Update `dusk-bls12_381` to v0.14
- Update `dusk-jubjub` to v0.15
- Update `dusk-plonk` to 0.21