### PR TITLE
Use hedged nonces in all Schnorr sign variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use hedged nonce generation in all Schnorr sign variants to prevent
+  secret key recovery under weak RNGs [P1.13-4]
 - Include generator point in VarGen Schnorr challenge hash
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `dusk-plonk` to 0.22.0-rc.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use hedged nonce generation in all Schnorr sign variants to prevent
-  secret key recovery under weak RNGs [P1.13-4]
+- Use hedged nonce generation with variant-specific domain separators
+  in all Schnorr sign variants to prevent secret key recovery under
+  weak RNGs
 - Include generator point in VarGen Schnorr challenge hash
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `dusk-plonk` to 0.22.0-rc.0

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -156,8 +156,9 @@ impl SecretKey {
     where
         R: RngCore + CryptoRng,
     {
-        // Create random scalar value for scheme, r
-        let r = JubJubScalar::random(rng);
+        // Create hedged nonce: mixes RNG output with (sk, msg) so that
+        // a weak RNG alone cannot cause nonce reuse.
+        let r = crate::nonce::hedged_nonce(rng, &self.0, msg);
 
         // Derive a point from r, to sign with the message
         // R = r * G

--- a/src/keys/secret/double.rs
+++ b/src/keys/secret/double.rs
@@ -63,7 +63,7 @@ impl SecretKey {
     {
         // Create hedged nonce: mixes RNG output with (sk, msg) so that
         // a weak RNG alone cannot cause nonce reuse.
-        let r = crate::nonce::hedged_nonce(rng, &self.0, message);
+        let r = crate::nonce::hedged_nonce_double(rng, &self.0, message);
 
         // Derive two points from r, to sign with the message
         // R = r * G

--- a/src/keys/secret/double.rs
+++ b/src/keys/secret/double.rs
@@ -5,8 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, JubJubScalar};
-use ff::Field;
+use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{PublicKey, SecretKey, SignatureDouble};
@@ -62,8 +61,9 @@ impl SecretKey {
     where
         R: RngCore + CryptoRng,
     {
-        // Create random scalar value for scheme, r
-        let r = JubJubScalar::random(rng);
+        // Create hedged nonce: mixes RNG output with (sk, msg) so that
+        // a weak RNG alone cannot cause nonce reuse.
+        let r = crate::nonce::hedged_nonce(rng, &self.0, message);
 
         // Derive two points from r, to sign with the message
         // R = r * G

--- a/src/keys/secret/var_gen.rs
+++ b/src/keys/secret/var_gen.rs
@@ -203,11 +203,11 @@ impl SecretKeyVarGen {
     {
         // Create hedged nonce: mixes RNG output with (sk, generator, msg)
         // so that a weak RNG alone cannot cause nonce reuse.
-        let r = crate::nonce::hedged_nonce_with_generator(
+        let r = crate::nonce::hedged_nonce_var_gen(
             rng,
             &self.sk,
             msg,
-            Some(self.generator()),
+            self.generator(),
         );
 
         // Derive a points from r, to sign with the message

--- a/src/keys/secret/var_gen.rs
+++ b/src/keys/secret/var_gen.rs
@@ -201,8 +201,14 @@ impl SecretKeyVarGen {
     where
         R: RngCore + CryptoRng,
     {
-        // Create random scalar value for scheme, r
-        let r = JubJubScalar::random(rng);
+        // Create hedged nonce: mixes RNG output with (sk, generator, msg)
+        // so that a weak RNG alone cannot cause nonce reuse.
+        let r = crate::nonce::hedged_nonce_with_generator(
+            rng,
+            &self.sk,
+            msg,
+            Some(self.generator()),
+        );
 
         // Derive a points from r, to sign with the message
         // R = r * G

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod error;
 mod keys;
+mod nonce;
 mod signatures;
 
 #[cfg(feature = "zk")]

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -17,11 +17,18 @@ use dusk_poseidon::{Domain, Hash};
 use ff::Field;
 use rand_core::{CryptoRng, RngCore};
 
-/// Generate a hedged nonce by mixing RNG output with deterministic
-/// data derived from the secret key and message.
+/// Domain separator tags for variant-specific nonce derivation.
 ///
-/// `nonce = H(random || sk || msg)` where H is the Poseidon hash
-/// truncated to the JubJub scalar field.
+/// These prevent cross-variant nonce reuse: without them, `sign` and
+/// `sign_double` would produce the same nonce for the same (sk, msg)
+/// under a broken RNG, enabling key recovery via the differing
+/// challenge hashes.
+const TAG_STANDARD: BlsScalar = BlsScalar::from_raw([1, 0, 0, 0]);
+const TAG_DOUBLE: BlsScalar = BlsScalar::from_raw([2, 0, 0, 0]);
+
+/// Generate a hedged nonce for the standard Schnorr signature.
+///
+/// `nonce = H(random || sk || tag_standard || msg)`
 pub(crate) fn hedged_nonce<R>(
     rng: &mut R,
     sk: &JubJubScalar,
@@ -30,48 +37,67 @@ pub(crate) fn hedged_nonce<R>(
 where
     R: RngCore + CryptoRng,
 {
-    hedged_nonce_with_generator(rng, sk, msg, None)
+    let (rng_bls, sk_bls) = prepare_inputs(rng, sk);
+    // H(rng || sk || tag || msg) -> JubJubScalar
+    Hash::digest_truncated(Domain::Other, &[rng_bls, sk_bls, TAG_STANDARD, msg])
+        [0]
 }
 
-/// Generate a hedged nonce, optionally including a generator point.
+/// Generate a hedged nonce for the double Schnorr signature.
 ///
-/// For the variable-generator variant, the generator is included in the
-/// hash to prevent cross-generator nonce reuse when the same key signs
-/// the same message under different generators with a broken RNG.
-pub(crate) fn hedged_nonce_with_generator<R>(
+/// `nonce = H(random || sk || tag_double || msg)`
+pub(crate) fn hedged_nonce_double<R>(
     rng: &mut R,
     sk: &JubJubScalar,
     msg: BlsScalar,
-    generator: Option<&JubJubExtended>,
 ) -> JubJubScalar
 where
     R: RngCore + CryptoRng,
 {
-    // Draw randomness from the RNG
+    let (rng_bls, sk_bls) = prepare_inputs(rng, sk);
+    // H(rng || sk || tag || msg) -> JubJubScalar
+    Hash::digest_truncated(Domain::Other, &[rng_bls, sk_bls, TAG_DOUBLE, msg])
+        [0]
+}
+
+/// Generate a hedged nonce for the variable-generator variant.
+///
+/// The generator coordinates serve as an implicit domain separator,
+/// so no additional tag is needed.
+///
+/// `nonce = H(random || sk || gen_x || gen_y || msg)`
+pub(crate) fn hedged_nonce_var_gen<R>(
+    rng: &mut R,
+    sk: &JubJubScalar,
+    msg: BlsScalar,
+    generator: &JubJubExtended,
+) -> JubJubScalar
+where
+    R: RngCore + CryptoRng,
+{
+    let (rng_bls, sk_bls) = prepare_inputs(rng, sk);
+    let gen_coords = generator.to_hash_inputs();
+    // H(rng || sk || gen_x || gen_y || msg) -> JubJubScalar
+    Hash::digest_truncated(
+        Domain::Other,
+        &[rng_bls, sk_bls, gen_coords[0], gen_coords[1], msg],
+    )[0]
+}
+
+/// Draw randomness and convert inputs to BlsScalar for Poseidon.
+fn prepare_inputs<R>(rng: &mut R, sk: &JubJubScalar) -> (BlsScalar, BlsScalar)
+where
+    R: RngCore + CryptoRng,
+{
     let rng_scalar = JubJubScalar::random(rng);
 
-    // Convert the secret key and RNG scalar to BlsScalar for Poseidon.
     // Both JubJubScalar and BlsScalar are 32-byte little-endian field
     // elements. The JubJub scalar field is smaller than the BLS scalar
     // field, so every JubJubScalar byte representation is a valid
     // BlsScalar.
     let rng_bls = BlsScalar::from_bytes_wide(&widen(rng_scalar.to_bytes()));
     let sk_bls = BlsScalar::from_bytes_wide(&widen(sk.to_bytes()));
-
-    match generator {
-        Some(g) => {
-            let gen_coords = g.to_hash_inputs();
-            // H(rng || sk || gen_x || gen_y || msg) -> JubJubScalar
-            Hash::digest_truncated(
-                Domain::Other,
-                &[rng_bls, sk_bls, gen_coords[0], gen_coords[1], msg],
-            )[0]
-        }
-        // H(rng || sk || msg) -> JubJubScalar
-        None => {
-            Hash::digest_truncated(Domain::Other, &[rng_bls, sk_bls, msg])[0]
-        }
-    }
+    (rng_bls, sk_bls)
 }
 
 /// Zero-extend a 32-byte array to 64 bytes for `from_bytes_wide`.

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Hedged nonce generation for Schnorr signing.
+//!
+//! Produces a nonce by hashing RNG output together with the secret key
+//! and message. This ensures that nonce reuse requires *both* a
+//! repeated RNG output *and* an identical (sk, message) pair —
+//! defending against weak or broken RNGs.
+
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubExtended, JubJubScalar};
+use dusk_poseidon::{Domain, Hash};
+use ff::Field;
+use rand_core::{CryptoRng, RngCore};
+
+/// Generate a hedged nonce by mixing RNG output with deterministic
+/// data derived from the secret key and message.
+///
+/// `nonce = H(random || sk || msg)` where H is the Poseidon hash
+/// truncated to the JubJub scalar field.
+pub(crate) fn hedged_nonce<R>(
+    rng: &mut R,
+    sk: &JubJubScalar,
+    msg: BlsScalar,
+) -> JubJubScalar
+where
+    R: RngCore + CryptoRng,
+{
+    hedged_nonce_with_generator(rng, sk, msg, None)
+}
+
+/// Generate a hedged nonce, optionally including a generator point.
+///
+/// For the variable-generator variant, the generator is included in the
+/// hash to prevent cross-generator nonce reuse when the same key signs
+/// the same message under different generators with a broken RNG.
+pub(crate) fn hedged_nonce_with_generator<R>(
+    rng: &mut R,
+    sk: &JubJubScalar,
+    msg: BlsScalar,
+    generator: Option<&JubJubExtended>,
+) -> JubJubScalar
+where
+    R: RngCore + CryptoRng,
+{
+    // Draw randomness from the RNG
+    let rng_scalar = JubJubScalar::random(rng);
+
+    // Convert the secret key and RNG scalar to BlsScalar for Poseidon.
+    // Both JubJubScalar and BlsScalar are 32-byte little-endian field
+    // elements. The JubJub scalar field is smaller than the BLS scalar
+    // field, so every JubJubScalar byte representation is a valid
+    // BlsScalar.
+    let rng_bls = BlsScalar::from_bytes_wide(&widen(rng_scalar.to_bytes()));
+    let sk_bls = BlsScalar::from_bytes_wide(&widen(sk.to_bytes()));
+
+    match generator {
+        Some(g) => {
+            let gen_coords = g.to_hash_inputs();
+            // H(rng || sk || gen_x || gen_y || msg) -> JubJubScalar
+            Hash::digest_truncated(
+                Domain::Other,
+                &[rng_bls, sk_bls, gen_coords[0], gen_coords[1], msg],
+            )[0]
+        }
+        // H(rng || sk || msg) -> JubJubScalar
+        None => {
+            Hash::digest_truncated(Domain::Other, &[rng_bls, sk_bls, msg])[0]
+        }
+    }
+}
+
+/// Zero-extend a 32-byte array to 64 bytes for `from_bytes_wide`.
+fn widen(bytes: [u8; 32]) -> [u8; 64] {
+    let mut wide = [0u8; 64];
+    wide[..32].copy_from_slice(&bytes);
+    wide
+}

--- a/tests/nonce_reuse.rs
+++ b/tests/nonce_reuse.rs
@@ -1,0 +1,255 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Regression tests for hedged nonce generation.
+//!
+//! A weak or broken RNG that repeats output must not cause nonce reuse
+//! across different (sk, message) pairs. These tests construct a
+//! constant-output RNG and verify that the hedged nonce derivation
+//! produces distinct nonces — making the classical nonce-reuse key
+//! recovery attack impossible.
+
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{GENERATOR_EXTENDED, JubJubScalar};
+use ff::Field;
+use jubjub_schnorr::{PublicKey, PublicKeyVarGen, SecretKey};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_core::{CryptoRng, RngCore};
+
+/// An RNG that always fills buffers with the same fixed byte.
+/// This simulates the worst-case scenario of a completely broken RNG.
+struct ConstRng(u8);
+
+impl RngCore for ConstRng {
+    fn next_u32(&mut self) -> u32 {
+        let mut buf = [0u8; 4];
+        self.fill_bytes(&mut buf);
+        u32::from_le_bytes(buf)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut buf = [0u8; 8];
+        self.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        dest.fill(self.0);
+    }
+
+    fn try_fill_bytes(
+        &mut self,
+        dest: &mut [u8],
+    ) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl CryptoRng for ConstRng {}
+
+/// With a broken RNG, signing two different messages must produce
+/// different nonces (different R values). If R values were the same,
+/// an attacker could recover the secret key.
+#[test]
+fn nonce_reuse_standard_sign() {
+    let mut rng = StdRng::seed_from_u64(0xdead);
+    let sk = SecretKey::random(&mut rng);
+    let pk = PublicKey::from(&sk);
+
+    let msg1 = BlsScalar::from(1u64);
+    let msg2 = BlsScalar::from(2u64);
+
+    let sig1 = sk.sign(&mut ConstRng(0x42), msg1);
+    let sig2 = sk.sign(&mut ConstRng(0x42), msg2);
+
+    // Both signatures must be valid
+    assert!(pk.verify(&sig1, msg1).is_ok());
+    assert!(pk.verify(&sig2, msg2).is_ok());
+
+    // The nonces must differ despite the identical RNG output,
+    // because the hedged derivation mixes in the message.
+    assert_ne!(
+        sig1.R(),
+        sig2.R(),
+        "nonce reuse detected: identical R with broken RNG"
+    );
+}
+
+/// Same test for the double signature variant.
+#[test]
+fn nonce_reuse_double_sign() {
+    let mut rng = StdRng::seed_from_u64(0xdead);
+    let sk = SecretKey::random(&mut rng);
+
+    let msg1 = BlsScalar::from(1u64);
+    let msg2 = BlsScalar::from(2u64);
+
+    let sig1 = sk.sign_double(&mut ConstRng(0x42), msg1);
+    let sig2 = sk.sign_double(&mut ConstRng(0x42), msg2);
+
+    assert_ne!(
+        sig1.R(),
+        sig2.R(),
+        "nonce reuse detected: identical R with broken RNG (double)"
+    );
+}
+
+/// Same test for the variable-generator variant.
+#[test]
+fn nonce_reuse_var_gen_sign() {
+    let mut rng = StdRng::seed_from_u64(0xdead);
+    let sk_base = SecretKey::random(&mut rng);
+    let generator = GENERATOR_EXTENDED * JubJubScalar::random(&mut rng);
+    let sk = sk_base.with_variable_generator(generator);
+    let pk = PublicKeyVarGen::from(&sk);
+
+    let msg1 = BlsScalar::from(1u64);
+    let msg2 = BlsScalar::from(2u64);
+
+    let sig1 = sk.sign(&mut ConstRng(0x42), msg1);
+    let sig2 = sk.sign(&mut ConstRng(0x42), msg2);
+
+    assert!(pk.verify(&sig1, msg1).is_ok());
+    assert!(pk.verify(&sig2, msg2).is_ok());
+
+    assert_ne!(
+        sig1.R(),
+        sig2.R(),
+        "nonce reuse detected: identical R with broken RNG (var_gen)"
+    );
+}
+
+/// With the same key and message but different generators and a broken
+/// RNG, a shared nonce scalar `r` would allow key recovery via
+/// `sk = (u1 - u2) / (c2 - c1)` (the challenges differ because the
+/// generator is part of the VarGen challenge hash). The hedged nonce
+/// mixes in the generator, so the scalar `r` itself differs and the
+/// attack produces a wrong key.
+#[test]
+fn key_recovery_cross_generator_fails() {
+    let mut rng = StdRng::seed_from_u64(0xface);
+    let sk_base = SecretKey::random(&mut rng);
+    let msg = BlsScalar::from(42u64);
+
+    let g1 = GENERATOR_EXTENDED * JubJubScalar::random(&mut rng);
+    let g2 = GENERATOR_EXTENDED * JubJubScalar::random(&mut rng);
+
+    let sk1 = sk_base.clone().with_variable_generator(g1);
+    let sk2 = sk_base.clone().with_variable_generator(g2);
+    // sk_base is used below for the recovery check
+
+    let pk1 = PublicKeyVarGen::from(&sk1);
+    let pk2 = PublicKeyVarGen::from(&sk2);
+
+    let sig1 = sk1.sign(&mut ConstRng(0x42), msg);
+    let sig2 = sk2.sign(&mut ConstRng(0x42), msg);
+
+    assert!(pk1.verify(&sig1, msg).is_ok());
+    assert!(pk2.verify(&sig2, msg).is_ok());
+
+    // Attempt the cross-generator key recovery attack.
+    // If the nonce scalar r is shared, u1 - u2 = (c2 - c1) * sk.
+    let u1 = sig1.u();
+    let u2 = sig2.u();
+
+    let hash_challenge = |r: &dusk_jubjub::JubJubExtended,
+                          pk: PublicKeyVarGen,
+                          m: BlsScalar|
+     -> JubJubScalar {
+        let r_coords = r.to_hash_inputs();
+        let pk_coords = pk.public_key().to_hash_inputs();
+        let gen_coords = pk.generator().to_hash_inputs();
+        dusk_poseidon::Hash::digest_truncated(
+            dusk_poseidon::Domain::Other,
+            &[
+                r_coords[0],
+                r_coords[1],
+                pk_coords[0],
+                pk_coords[1],
+                gen_coords[0],
+                gen_coords[1],
+                m,
+            ],
+        )[0]
+    };
+
+    let c1 = hash_challenge(sig1.R(), pk1, msg);
+    let c2 = hash_challenge(sig2.R(), pk2, msg);
+
+    let delta_u = u1 - u2;
+    let delta_c = c2 - c1;
+
+    if let Some(delta_c_inv) = Option::<JubJubScalar>::from(delta_c.invert()) {
+        let recovered_sk = SecretKey::from(delta_u * delta_c_inv);
+
+        assert_ne!(
+            recovered_sk, sk_base,
+            "cross-generator key recovery succeeded — generator not \
+             mixed into nonce derivation"
+        );
+    }
+}
+
+/// Verify that the classical nonce-reuse key recovery attack fails
+/// when hedged nonces are used.
+///
+/// Attack: given two signatures (u1, R) and (u2, R) with the same R,
+///   sk = (u1 - u2) / (c2 - c1)
+/// With hedged nonces, R1 != R2 even under a broken RNG, so the
+/// "recovered" key will be wrong.
+#[test]
+fn key_recovery_attack_fails() {
+    let mut rng = StdRng::seed_from_u64(0xbeef);
+    let sk = SecretKey::random(&mut rng);
+    let pk = PublicKey::from(&sk);
+
+    let msg1 = BlsScalar::from(100u64);
+    let msg2 = BlsScalar::from(200u64);
+
+    let sig1 = sk.sign(&mut ConstRng(0xAA), msg1);
+    let sig2 = sk.sign(&mut ConstRng(0xAA), msg2);
+
+    assert!(pk.verify(&sig1, msg1).is_ok());
+    assert!(pk.verify(&sig2, msg2).is_ok());
+
+    // Attempt the key recovery attack assuming same nonce
+    let u1 = sig1.u();
+    let u2 = sig2.u();
+
+    // If R1 == R2 (nonce reuse), then u1 - u2 = (c2 - c1) * sk.
+    // But with hedged nonces R1 != R2, so the formula yields garbage.
+    // We verify the "recovered" key does NOT match the real public key.
+    // Recompute challenge hashes the same way the signature scheme does
+    let hash_challenge = |r: &dusk_jubjub::JubJubExtended,
+                          pk: &PublicKey,
+                          m: BlsScalar|
+     -> JubJubScalar {
+        let r_coords = r.to_hash_inputs();
+        let pk_coords = pk.as_ref().to_hash_inputs();
+        dusk_poseidon::Hash::digest_truncated(
+            dusk_poseidon::Domain::Other,
+            &[r_coords[0], r_coords[1], pk_coords[0], pk_coords[1], m],
+        )[0]
+    };
+
+    let c1 = hash_challenge(sig1.R(), &pk, msg1);
+    let c2 = hash_challenge(sig2.R(), &pk, msg2);
+
+    let delta_u = u1 - u2;
+    let delta_c = c2 - c1;
+
+    // If delta_c is zero, the attack is inapplicable regardless
+    if let Some(delta_c_inv) = Option::<JubJubScalar>::from(delta_c.invert()) {
+        let recovered_sk = SecretKey::from(delta_u * delta_c_inv);
+
+        assert_ne!(
+            recovered_sk, sk,
+            "key recovery attack succeeded — nonce hedging is broken"
+        );
+    }
+}

--- a/tests/nonce_reuse.rs
+++ b/tests/nonce_reuse.rs
@@ -253,3 +253,78 @@ fn key_recovery_attack_fails() {
         );
     }
 }
+
+/// With the same key and message under a broken RNG, `sign` and
+/// `sign_double` currently call `hedged_nonce` with identical inputs,
+/// producing the same nonce `r`. Since the challenge hashes differ
+/// between variants, an attacker with both signatures can recover the
+/// secret key: `sk = (u1 - u2) / (c2 - c1)`.
+///
+/// This test demonstrates that cross-variant nonce reuse is prevented
+/// by variant-specific domain separation in the nonce derivation.
+#[test]
+fn key_recovery_cross_variant_fails() {
+    let mut rng = StdRng::seed_from_u64(0xcafe);
+    let sk = SecretKey::random(&mut rng);
+    let pk = PublicKey::from(&sk);
+    let msg = BlsScalar::from(77u64);
+
+    // Sign the same message with the same key using both variants
+    // under a broken RNG that always produces the same output.
+    let sig_std = sk.sign(&mut ConstRng(0x42), msg);
+    let sig_dbl = sk.sign_double(&mut ConstRng(0x42), msg);
+
+    // Both signatures must be independently valid
+    assert!(pk.verify(&sig_std, msg).is_ok());
+
+    let pk_dbl = jubjub_schnorr::PublicKeyDouble::from(&sk);
+    assert!(pk_dbl.verify(&sig_dbl, msg).is_ok());
+
+    // Attempt the cross-variant key recovery attack.
+    // Standard challenge: H(R_x, R_y, pk_x, pk_y, msg)
+    let r_std = sig_std.R();
+    let r_std_coords = r_std.to_hash_inputs();
+    let pk_coords = pk.as_ref().to_hash_inputs();
+    let c_std: JubJubScalar = dusk_poseidon::Hash::digest_truncated(
+        dusk_poseidon::Domain::Other,
+        &[
+            r_std_coords[0],
+            r_std_coords[1],
+            pk_coords[0],
+            pk_coords[1],
+            msg,
+        ],
+    )[0];
+
+    // Double challenge: H(R_x, R_y, R'_x, R'_y, pk_x, pk_y, msg)
+    let r_dbl = sig_dbl.R();
+    let r_dbl_coords = r_dbl.to_hash_inputs();
+    let r_prime = sig_dbl.R_prime();
+    let r_prime_coords = r_prime.to_hash_inputs();
+    let c_dbl: JubJubScalar = dusk_poseidon::Hash::digest_truncated(
+        dusk_poseidon::Domain::Other,
+        &[
+            r_dbl_coords[0],
+            r_dbl_coords[1],
+            r_prime_coords[0],
+            r_prime_coords[1],
+            pk_coords[0],
+            pk_coords[1],
+            msg,
+        ],
+    )[0];
+
+    // If nonce r is shared: u_std - u_dbl = (c_dbl - c_std) * sk
+    let delta_u = sig_std.u() - sig_dbl.u();
+    let delta_c = c_dbl - c_std;
+
+    if let Some(delta_c_inv) = Option::<JubJubScalar>::from(delta_c.invert()) {
+        let recovered_sk = SecretKey::from(delta_u * delta_c_inv);
+
+        assert_ne!(
+            recovered_sk, sk,
+            "cross-variant key recovery succeeded — sign and \
+             sign_double share nonces without domain separation"
+        );
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -64,7 +64,7 @@ fn serde_signature() -> Result<(), Box<dyn std::error::Error>> {
     let sig = sk.sign(&mut rng, msg);
     let ser = assert_canonical_json(
         &sig,
-        "\"3RaYppgCj8gGPTqx7R2RCvL8L8VwtHEXNuMrmGYiyfHBYgsLTPfc96DoyD6jhD8PhN4aRycx5jL6kNcCL2ieVEct\"",
+        "\"YPcFwsvLhkNWfCc266wtGMjyxjmdrFK4YSZGPSzqTsQaVdZdvuDFMUCdaadYgtwviYwNAERihs1S4aDR3dc5fif\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sig, deser);
@@ -93,7 +93,7 @@ fn serde_signature_double() -> Result<(), Box<dyn std::error::Error>> {
     let sig = sk.sign_double(&mut rng, msg);
     let ser = assert_canonical_json(
         &sig,
-        "\"2VLaiWNVxxsCgBKu7qSXY6PYN12Xmrqg2ASGhjs7TMgx8fQg7esQXhqomzKK8gcDoMEUCsheFVDjRpEpmAwCbSLoRnZ9yJWDPwude6Zi1RLEFDKsahXpBtdQkrnX6YYxfBhy\"",
+        "\"29JmtoxVsbNxbtQwrGKcxZsS2Ez3qfyKgK9RZh6mdPzKSKE5quDbo3v3WaXrqDYe8P6rgPpoq7jfezZyvCYJ4nXqRsRH9SUqeqZKHTBrVrgmFE8QZcfg7LXJcRcaTB8HdwBd\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sig, deser);
@@ -134,7 +134,7 @@ fn serde_signature_var_gen() -> Result<(), Box<dyn std::error::Error>> {
     let sig = sk.sign(&mut rng, msg);
     let ser = assert_canonical_json(
         &sig,
-        "\"2Z8gXEx2czaUDtWkLYRWrfibfzZnD7LWbWStjeLSmi3xX9C2sp1QWRPC1KGRGLDhTNYEfymTxkcXwbx8Zsu9LJL6\"",
+        "\"3qfHnHffadiqm7XVY8kjHPyzGTXiPDRNgcWtAifwJmXpjyzsCN4ZgLtRvAgxdSBqXPDR38BsyPrtHAgqT6HoMYxM\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sig, deser);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -64,7 +64,7 @@ fn serde_signature() -> Result<(), Box<dyn std::error::Error>> {
     let sig = sk.sign(&mut rng, msg);
     let ser = assert_canonical_json(
         &sig,
-        "\"YPcFwsvLhkNWfCc266wtGMjyxjmdrFK4YSZGPSzqTsQaVdZdvuDFMUCdaadYgtwviYwNAERihs1S4aDR3dc5fif\"",
+        "\"4Ck7MhW5SJrdKAuR6REJBQLNcPr3uBBVPkipXvDfhFfXwUdyokH3ZMKsPEcbzmNmPBpriBmKq3kugjs3oCztFixs\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sig, deser);
@@ -93,7 +93,7 @@ fn serde_signature_double() -> Result<(), Box<dyn std::error::Error>> {
     let sig = sk.sign_double(&mut rng, msg);
     let ser = assert_canonical_json(
         &sig,
-        "\"29JmtoxVsbNxbtQwrGKcxZsS2Ez3qfyKgK9RZh6mdPzKSKE5quDbo3v3WaXrqDYe8P6rgPpoq7jfezZyvCYJ4nXqRsRH9SUqeqZKHTBrVrgmFE8QZcfg7LXJcRcaTB8HdwBd\"",
+        "\"iHdQeckrz3UmicDqvHJRBjpQjg9U96QECj3qq9s8txc5dwMJXyb8W7FAb88igmjaaVWSSqVgCEqJpvUzDXNHwAYytut4PNQ58h2JN4mt79XHAq3dpvpVdp9MJG59KQ5AVWu\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sig, deser);


### PR DESCRIPTION
Mix RNG output with a Poseidon hash of (rng_scalar, secret_key, message) to derive the signing nonce. This prevents secret key recovery when a weak or broken RNG produces repeated output, since different messages still yield distinct nonces.

Each sign variant includes a unique domain separator in the nonce hash to prevent cross-variant nonce reuse:
- `sign`: `H(rng || sk || tag_standard || msg)`
- `sign_double`: `H(rng || sk || tag_double || msg)`
- `sign` (VarGen): `H(rng || sk || gen_x || gen_y || msg)` — generator coordinates serve as implicit domain separator

Without variant-specific separation, `sign` and `sign_double` would produce the same nonce for the same (sk, msg) pair under a broken RNG. Since the challenge hashes differ between variants, an attacker with both signatures could recover the secret key.

Verification is unchanged — old signatures remain valid.